### PR TITLE
Fix incorrect texture region setters

### DIFF
--- a/Resources/GamePieces/BishopPieceRes.gd
+++ b/Resources/GamePieces/BishopPieceRes.gd
@@ -6,7 +6,9 @@ func _determine_moveset():
 	pass
 
 func _initializeTex(isWhite: bool) -> Texture2D:
-	if isWhite:
-		return piecesWhite.setRegion(48, 0, 16, 16).get_atlas()
-	else:
-		return piecesBlack.setRegion(48, 0, 16, 16).get_atlas()
+       if isWhite:
+               piecesWhite.set_region(Rect2(48, 0, 16, 16))
+               return piecesWhite
+       else:
+               piecesBlack.set_region(Rect2(48, 0, 16, 16))
+               return piecesBlack

--- a/Resources/GamePieces/KnightPieceRes.gd
+++ b/Resources/GamePieces/KnightPieceRes.gd
@@ -6,7 +6,9 @@ func _determine_moveset():
 	pass
 
 func _initializeTex(isWhite: bool) -> Texture2D:
-	if isWhite:
-		return piecesWhite.setRegion(16, 0, 16, 16).get_atlas()
-	else:
-		return piecesBlack.setRegion(16, 0, 16, 16).get_atlas()
+       if isWhite:
+               piecesWhite.set_region(Rect2(16, 0, 16, 16))
+               return piecesWhite
+       else:
+               piecesBlack.set_region(Rect2(16, 0, 16, 16))
+               return piecesBlack

--- a/Resources/GamePieces/QueenPieceRes.gd
+++ b/Resources/GamePieces/QueenPieceRes.gd
@@ -6,7 +6,9 @@ func _determine_moveset():
 	pass
 
 func _initializeTex(isWhite: bool) -> Texture2D:
-	if isWhite:
-		return piecesWhite.setRegion(64, 0, 16, 16).get_atlas()
-	else:
-		return piecesBlack.setRegion(64, 0, 16, 16).get_atlas()
+       if isWhite:
+               piecesWhite.set_region(Rect2(64, 0, 16, 16))
+               return piecesWhite
+       else:
+               piecesBlack.set_region(Rect2(64, 0, 16, 16))
+               return piecesBlack

--- a/Resources/GamePieces/RookPieceRes.gd
+++ b/Resources/GamePieces/RookPieceRes.gd
@@ -6,7 +6,9 @@ func _determine_moveset():
 	pass
 
 func _initializeTex(isWhite: bool) -> Texture2D:
-	if isWhite:
-		return piecesWhite.setRegion(32, 0, 16, 16).get_atlas()
-	else:
-		return piecesBlack.setRegion(32, 0, 16, 16).get_atlas()
+       if isWhite:
+               piecesWhite.set_region(Rect2(32, 0, 16, 16))
+               return piecesWhite
+       else:
+               piecesBlack.set_region(Rect2(32, 0, 16, 16))
+               return piecesBlack


### PR DESCRIPTION
## Summary
- correct invalid `setRegion` calls in piece resource scripts
- return `AtlasTexture` directly instead of calling `get_atlas`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68740865da148322a3028ca7365ecd07